### PR TITLE
add temp CI job to test syspolicy impact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,22 @@ jobs:
         nix-build -o result -A ghc.backend
         nix-build -o result -A ghc.server
         nix-build -o result -A ghcjs.frontend
+  macos_perf_test:
+    name: Build on macos_perf_test
+    runs-on: macos-latest
+    steps:
+    - name: Disable syspolicy assessments
+      run: |
+        spctl --status
+        sudo spctl --master-disable
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v8
+    - uses: cachix/cachix-action@v6
+      with:
+        name: purehs
+
+    - name: build
+      run: |
+        nix-build -o result -A ghc.backend
+        nix-build -o result -A ghc.server
+        nix-build -o result -A ghcjs.frontend


### PR DESCRIPTION
Starting in Catalina, macOS runs a syspolicyd "assessment" that hits the network for each binary/script executable. It does cache these results, but Nix tends to introduce many "new" executables per build. (You can read more about this at https://github.com/NixOS/nix/issues/3789).

This PR adds a temporary, redundant macOS job with these assessments disabled. I'm hoping you can adopt it for a few weeks to help me collect more data on how this affects real projects.

(Like the other, this should hopefully run clean on PR 🤞)